### PR TITLE
[CI] Use `temurin` instead of deprecated `adopt`

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
         cache: 'gradle'
 


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from `adopt` to `temurin` to keep receiving software and security updates. More details in the Good-bye AdoptOpenJDK post: https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/.